### PR TITLE
added elm-version to the package

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,5 +10,6 @@
     "dependencies": {
         "elm-lang/core": "1.1.0 <= v < 2.0.0",
         "evancz/elm-html": "2.0.0 <= v < 3.0.0"
-    }
+    },
+    "elm-version": "0.15.0 <= v < 0.16.0"
 }

--- a/src/TypedStyles.elm
+++ b/src/TypedStyles.elm
@@ -32,11 +32,11 @@ animation, transition, and transformation bindings.
 
 -}
 
-import Html(..)
-import Html.Attributes(..)
-import List(..)
-import Color(..)
-import String(join)
+import Html            exposing (..)
+import Html.Attributes exposing (..)
+import List            exposing (..)
+import Color           exposing (..)
+import String          exposing (join)
 
 type alias CSSValue = String
 type alias CSSKey   = String


### PR DESCRIPTION
```
Error: Unable to get elm-package.json for identicalsnowflake/elm-typed-styles 2.0.0
Missing field "elm-version", acceptable versions of the Elm Platform (e.g. "0.15.0 <= v < 0.16.0").
    Check out an example elm-package.json file here:
    <https://raw.githubusercontent.com/evancz/elm-html/master/elm-package.json>
```

I got the above error and suspect that this may solve it.
